### PR TITLE
Use @slot for slot descriptions in template comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ For the following component
 ```html
 <template>
   <div>
-    <!-- Use this slot header -->
+    <!-- @slot Use this slot header -->
     <slot name="header"></slot>
 
     <table class="grid">
       <!-- -->
     </table>
 
-    <!-- Use this slot footer -->
+    <!-- @slot Use this slot footer -->
     <slot name="footer"></slot>
   </div>
 </template>
@@ -437,10 +437,10 @@ this.$emit('success', {
 ```html
 <template>
   <div>
-    <!-- Use this slot header -->
+    <!-- @slot Use this slot header -->
     <slot name="header"></slot>
 
-    <!-- Use this slot footer -->
+    <!-- @slot Use this slot footer -->
     <slot name="footer"></slot>
   </div>
 </template>

--- a/src/utils/getSlots.js
+++ b/src/utils/getSlots.js
@@ -10,7 +10,9 @@ export default function getSlots(parts) {
 
 		const parser = new HtmlParser({
 			oncomment: (data) => {
-				lastComment = data.trim()
+				if (data.search(/\@slot/) !== -1) {
+					lastComment = data.replace('@slot', '').trim()
+				}
 			},
 			ontext: (text) => {
 				if (text.trim()) {

--- a/tests/components/button/Button.vue
+++ b/tests/components/button/Button.vue
@@ -1,6 +1,6 @@
 <template>
 	<button class="buttonComponent" @click.prevent="onClick">
-		<!-- Use this slot default -->
+		<!-- @slot Use this slot default -->
 		<slot></slot>
 	</button>
 </template>

--- a/tests/components/grid/Grid.vue
+++ b/tests/components/grid/Grid.vue
@@ -1,6 +1,6 @@
 <template>
 
-	<!-- Use this slot header -->
+	<!-- @slot Use this slot header -->
 	<slot name="header"></slot>
 	<table class="grid">
 		<thead>
@@ -21,7 +21,7 @@
 		</tbody>
 	</table>
 
-	<!-- Use this slot footer -->
+	<!-- @slot Use this slot footer -->
 	<slot name="footer"></slot>
 </template>
 


### PR DESCRIPTION
Suggesting using @slot in the HTML comment for Vue templates so that it's more inline with the other notations such as @model and @event. This would also allow for another comment to follow the slot description and not override it.

Love the project. Keep up the great work!