### PR TITLE
Add parseSource method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-# vue-docgen-api
+# vue-docgen-api (Fork)
 [![npm](https://img.shields.io/npm/v/vue-docgen-api.svg)](https://www.npmjs.com/package/vue-docgen-api)
+
+**This fork adds a `parseSource` method to parse plain sources instead of files only**
 
 `vue-docgen-api` is a toolbox to help extracting information from [Vue][] components, and generate documentation from it.
 
@@ -10,7 +12,7 @@ Use [babel][] and [jsdoc-api][] to compile the code and analyze the contents of 
 Install the module directly from npm:
 
 ```
-npm install vue-docgen-api --save-dev
+npm install git://github.com/Radiergummi/vue-docgen-api --save-dev
 ```
 
 ## API
@@ -18,16 +20,14 @@ npm install vue-docgen-api --save-dev
 The tool can be used programmatically to extract component information and customize the extraction process:
 
 ```js
-var vueDocs = require('vue-docgen-api');
-var componentInfo = vueDocs.parse(filePath);
+const vueDocs = require('vue-docgen-api');
+
+// from file
+const componentFileInfo = vueDocs.parseFile(filePath);
+
+// from source
+const componentSourceInfo = vueDocs.parseSource(sourceCode, filePath);
 ```
-
-### parse(filePath)
-
-| Parameter |  Type | Description |
-| -------------- | ------ | --------------- |
-| filePath       | string | The file path |
-
 
 ## Using JSDoc tags
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-docgen-api",
-  "version": "2.1.6",
+  "version": "2.2.6",
   "description": "Toolbox to extract information from Vue component files for documentation generation purposes.",
   "bugs": {
     "url": "https://github.com/vue-styleguidist/vue-docgen-api/issues"

--- a/src/main.js
+++ b/src/main.js
@@ -5,8 +5,8 @@ function parseFile(path) {
   return parseFile(path);
 }
 
-function parseSource(src) {
-	return parseSource(src);
+function parseSource(src, path) {
+	return parseSource(src, path);
 }
 
 export {

--- a/src/main.js
+++ b/src/main.js
@@ -1,12 +1,17 @@
 import * as utils from './utils';
-import parse from './parse';
+import { parseFile, parseSource } from './parse';
 
-function defaultParse(src) {
-  return parse(src);
+function parseFile(path) {
+  return parseFile(path);
+}
+
+function parseSource(src) {
+	return parseSource(src);
 }
 
 export {
-	defaultParse as parse,
+	parseFile,
+	parseSource,
 	utils,
 };
 

--- a/src/parse.js
+++ b/src/parse.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import * as utils from './utils';
 import stateDoc from './utils/stateDoc';
 
-export default function parse(file) {
+export const parseFile = function(file) {
 	const source = fs.readFileSync(file, { encoding: 'utf-8' });
 	if (source === '') {
 		throw new Error('The document is empty');
@@ -10,6 +10,18 @@ export default function parse(file) {
 	stateDoc.file = file;
 	stateDoc.saveComponent(source, file);
 	const component = utils.getSandbox(stateDoc.jscodeReqest, file).default;
+	const vueDoc = utils.getVueDoc(stateDoc, component);
+	return vueDoc;
+}
+
+export const parseSource = function(source, path) {
+	if (source === '') {
+		throw new Error('The document is empty');
+	}
+	
+	stateDoc.file = path;
+	stateDoc.saveComponent(source, path);
+	const component = utils.getSandbox(stateDoc.jscodeReqest, path).default;
 	const vueDoc = utils.getVueDoc(stateDoc, component);
 	return vueDoc;
 }


### PR DESCRIPTION
This PR adds support for parsing source strings instead of file paths. Therefore, it exports two methods: `parseFile` and `parseSource`. It would be easy to keep the `parse` method in `main.js` as an alias to `parseFile` to preserve compatibility.  
This feature is quite helpful for documentation generators that process files in separate modules at an earlier stage.

*Note: Please ignore the README changes, they are specific to my fork.*