### PR TITLE
Add support for typescript components

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "htmlparser2": "^3.9.2",
     "jsdoc-api": "^3.0.0",
     "lru-cache": "^4.1.0",
+    "typescript": "^2.5.0",
     "vue": "^2.5.2",
     "vue-template-compiler": "^2.5.2"
   },

--- a/src/parse.js
+++ b/src/parse.js
@@ -9,7 +9,7 @@ export const parse = function(file) {
 	}
 	stateDoc.file = file;
 	stateDoc.saveComponent(source, file);
-	const component = utils.getSandbox(stateDoc.jscodeReqest, file).default;
+	const component = utils.getSandbox(stateDoc, file).default;
 	const vueDoc = utils.getVueDoc(stateDoc, component);
 	return vueDoc;
 }
@@ -21,7 +21,7 @@ export const parseSource = function(source, path) {
 
 	stateDoc.file = path;
 	stateDoc.saveComponent(source, path);
-	const component = utils.getSandbox(stateDoc.jscodeReqest, path).default;
+	const component = utils.getSandbox(stateDoc, path).default;
 	const vueDoc = utils.getVueDoc(stateDoc, component);
 	return vueDoc;
 }

--- a/src/utils/getDocFile.js
+++ b/src/utils/getDocFile.js
@@ -1,12 +1,12 @@
 const jsdoc = require('jsdoc-api');
-const getParseBabel = require('./getParseBabel');
 const path = require('path');
+const { parseModule } = require('./parseModule')
 
-export default function getDocFile (jscodeReqest, file) {
+export default function getDocFile (source, file, lang) {
 	try {
-		const babelifycode = getParseBabel(jscodeReqest, '2017', true);
+		const parsedSource = parseModule(source, lang, '2017')
 		let docReturn = jsdoc.explainSync({
-				source: babelifycode.code,
+				source: parsedSource,
 				configure: path.join(path.dirname(__dirname), '..', 'config.json'),
 		}).filter(obj => obj.undocumented !== true)
 			.map( obj => {

--- a/src/utils/getParseTypescript.js
+++ b/src/utils/getParseTypescript.js
@@ -1,0 +1,9 @@
+import typescript from 'typescript'
+
+export default function(source) {
+  return typescript.transpileModule(source, {
+    compilerOptions: {
+      target: 'es2017',
+    }
+  })
+}

--- a/src/utils/parseModule.js
+++ b/src/utils/parseModule.js
@@ -1,0 +1,15 @@
+import getParseTypescript from './getParseTypescript'
+const getParseBabel = require('./getParseBabel');
+
+export function parseModule(source, type, preset) {
+  const comment = !!preset
+  preset = preset || '2015'
+  switch(type) {
+    case 'ts':
+      const tsOutput = getParseTypescript(source)
+      return getParseBabel(tsOutput.outputText, preset, comment).code;
+      break;
+    default:
+      return getParseBabel(source, preset, comment).code;
+  }
+}

--- a/src/utils/stateDoc.js
+++ b/src/utils/stateDoc.js
@@ -10,6 +10,7 @@ class stateDoc {
 		this.sourceComponent = '';
 		this.docMixins = [];
 		this.jscodeReqest = '';
+		this.jscodeLang = undefined;
 		this.docTemp = '';
 		this.slots;
 	}
@@ -23,13 +24,14 @@ class stateDoc {
 			const parts = parser(source, 'name');
 			this.slots = getSlots(parts);
 			this.jscodeReqest = getComponentModuleJSCode(parts, source, file);
-			const doc = this.getDocFile(this.jscodeReqest, file);
+			this.jscodeLang = parts.script.lang
+			const doc = this.getDocFile(this.jscodeReqest, file, this.jscodeLang);
 			this.docComponent = doc;
 		}
 	}
 
-	getDocFile(source, file){
-		this.docTemp = getDocFile(source, file)
+	getDocFile(source, file, lang){
+		this.docTemp = getDocFile(source, file, lang)
 		return this.docTemp;
 	}
 

--- a/tests/components/grid-typescript/Grid.vue
+++ b/tests/components/grid-typescript/Grid.vue
@@ -1,0 +1,174 @@
+<template>
+	<!-- @slot Use this slot header -->
+	<slot name="header"></slot>
+	<table class="grid">
+		<thead>
+			<tr>
+				<th v-for="key in columns" @click="sortBy(key)" :class="{ active: sortKey == key }">
+					{{ key | capitalize }}
+					<span class="arrow" :class="sortOrders[key] > 0 ? 'asc' : 'dsc'">
+					</span>
+				</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr v-for="entry in filteredData">
+				<td v-for="key in columns">
+					{{entry[key]}}
+				</td>
+			</tr>
+		</tbody>
+	</table>
+
+	<!-- @slot Use this slot footer -->
+	<slot name="footer"></slot>
+</template>
+
+<script lang='ts'>
+import Vue from 'vue'
+import { text } from "./utils";
+
+interface IData {
+  sortKey: string
+  sortOrders: Record<string, number>
+}
+/**
+ * This is an example of creating a reusable grid component and using it with external data.
+ * @version 1.0.5
+ * @author [Rafael](https://github.com/rafaesc92)
+ * @since Version 1.0.1
+ */
+export default Vue.extend({
+  name: "grid",
+  props: {
+    /**
+     * object/array defaults should be returned from a factory function
+     * @version 1.0.5
+     * @since Version 1.0.1
+     * @see See [Wikipedia](https://en.wikipedia.org/wiki/Web_colors#HTML_color_names) for a list of color names
+     * @link See [Wikipedia](https://en.wikipedia.org/wiki/Web_colors#HTML_color_names) for a list of color names
+     */
+    msg: {
+      type: [String, Number],
+      default: text
+    },
+    /**
+     * describe data
+     * @version 1.0.5
+     */
+    data: Array,
+
+    images: {
+      type: Array,
+      default: function() {
+        return [{}];
+      }
+    },
+    /**
+     * prop function
+     */
+    propFunc: {
+      default: function() {}
+    },
+    /**
+     * get columns list
+     */
+    columns: {
+      type: Array,
+    },
+    /**
+     * filter key
+     * @ignore
+     */
+    filterKey: {
+      type: String,
+      default: "example"
+    }
+  },
+  data() : IData {
+    var sortOrders = {};
+    ;(this as any).columns.forEach(function(key) {
+      sortOrders[key] = 1;
+    });
+    return {
+      sortKey: "",
+      sortOrders: sortOrders
+    };
+  },
+  computed: {
+    filteredData() : IData {
+      var sortKey = this.sortKey;
+      var filterKey = this.filterKey && this.filterKey.toLowerCase();
+      var order = this.sortOrders[sortKey] || 1;
+      var data = this.data;
+      if (filterKey) {
+        data = data.filter(function(row) {
+          return Object.keys(row).some(function(key) {
+            return (
+              String(row[key])
+                .toLowerCase()
+                .indexOf(filterKey) > -1
+            );
+          });
+        });
+      }
+      if (sortKey) {
+        data = data.slice().sort(function(a, b) {
+          a = a[sortKey];
+          b = b[sortKey];
+          return (a === b ? 0 : a > b ? 1 : -1) * order;
+        });
+      }
+      return data;
+    }
+  },
+  filters: {
+    capitalize(str: string) : string {
+      return str.charAt(0).toUpperCase() + str.slice(1);
+    }
+  },
+  methods: {
+   /**
+   * Sets the order
+   *
+   * @public
+   * @version 1.0.5
+   * @since Version 1.0.1
+   * @param {string} key Key to order
+   * @returns {string} Test
+   */
+    sortBy(key: string) : void {
+      this.sortKey = key;
+      this.sortOrders[key] = this.sortOrders[key] * -1;
+
+      /**
+			 * Success event.
+			 *
+			 * @event success
+			 * @type {object}
+			 */
+      this.$emit("example", {
+        demo: "example success"
+      });
+    },
+
+    hiddenMethod() : void {
+      /**
+			 * Error event.
+			 *
+			 * @event error
+			 * @type {object}
+			 */
+      this.$emit("error", {
+        demo: "example error"
+      });
+    }
+  }
+})
+</script>
+
+<style scoped>
+.grid {
+  margin-bottom: 20px;
+}
+</style>

--- a/tests/components/grid-typescript/utils.js
+++ b/tests/components/grid-typescript/utils.js
@@ -1,0 +1,3 @@
+module.exports = {
+	text: 'this is a secret',
+}

--- a/tests/parse.js
+++ b/tests/parse.js
@@ -3,6 +3,7 @@ var api = require("../dist/main");
 var grid = path.join(__dirname, "./components/grid/Grid.vue");
 var button = path.join(__dirname, "./components/button/Button.vue");
 var exampleVuex = path.join(__dirname, "./components/vuex/example.vue");
+var typescriptGrid = path.join(__dirname, "./components/grid-typescript/Grid.vue");
 const expect = require("chai").expect;
 let docGrid;
 let docButton;
@@ -342,5 +343,127 @@ describe("test example vuex", () => {
 
 	it("should dont have slots.", () => {
 		expect(Object.keys(docVuex["slots"]).length).to.equal(0);
+	});
+});
+
+describe("tests typescript grid", () => {
+	docGrid = api.parse(typescriptGrid);
+
+	it("should return an object", () => {
+		expect(docGrid).to.be.an("object");
+	});
+
+	it("The component name should be grid", () => {
+		expect(docGrid.displayName).to.equal("grid");
+	});
+
+	it("should the component has tags", () => {
+		expect(typeof docGrid["tags"] !== "undefined").to.be.true;
+	});
+
+	it("should the component has authors", () => {
+		expect(typeof docGrid["tags"]["author"] !== "undefined").to.be.true;
+	});
+
+	it("should the component has description", () => {
+		expect(typeof docGrid["description"] !== "undefined").to.be.true;
+	});
+
+	it("should has methods", () => {
+		expect(typeof docGrid["methods"] !== "undefined").to.be.true;
+	});
+
+	it("should the component has one method", () => {
+		expect(Object.keys(docGrid["methods"]).length).to.equal(1);
+	});
+
+	it("should has props", () => {
+		expect(typeof docGrid["props"] !== "undefined").to.be.true;
+	});
+
+	it("should the component has version", () => {
+		expect(typeof docGrid["tags"]["version"] !== "undefined").to.be.true;
+	});
+
+	it("should the component has four props", () => {
+		expect(Object.keys(docGrid["props"]).length).to.equal(6);
+	});
+
+	it("grid component should have a msg prop as string|number type", () => {
+		expect(docGrid["props"]["msg"]["type"]["name"]).to.equal("string|number");
+	});
+
+	it("grid component should have a filterKey prop as string type", () => {
+		expect(docGrid["props"]["filterKey"]["type"]["name"]).to.equal("string");
+	});
+
+	it("grid component should have a propFunc prop as func type", () => {
+		expect(docGrid["props"]["propFunc"]["type"]["name"]).to.equal("func");
+	});
+
+	it("grid component should have a images prop as Array type", () => {
+		expect(docGrid["props"]["images"]["type"]["name"]).to.equal("array");
+	});
+
+	it("grid component should have a data prop as Array type", () => {
+		expect(docGrid["props"]["data"]["type"]["name"]).to.equal("array");
+	});
+
+	it("grid component should have a columns prop as Array type", () => {
+		expect(docGrid["props"]["columns"]["type"]["name"]).to.equal("array");
+	});
+
+	it("should the prop msg has four tags", () => {
+		expect(Object.keys(docGrid["props"]["msg"]["tags"]).length).to.equal(4);
+	});
+
+	it("should the component has two event", () => {
+		expect(Object.keys(docGrid["events"]).length).to.equal(2);
+	});
+
+	it("should the component has event, it called success", () => {
+		expect(typeof docGrid["events"]["success"] !== "undefined").to.be.true;
+	});
+
+	it("should the description of success event is Success event.", () => {
+		expect(docGrid["events"]["success"]["description"]).to.equal(
+			"Success event."
+		);
+	});
+
+	it("should the component has event, it called error", () => {
+		expect(typeof docGrid["events"]["error"] !== "undefined").to.be.true;
+	});
+
+	it("should the description of error event is Error event.", () => {
+		expect(docGrid["events"]["error"]["description"]).to.equal("Error event.");
+	});
+
+	it("should the type of error event is object.", () => {
+		expect(docGrid["events"]["error"]["type"]["names"][0]).to.equal("object");
+	});
+
+	it("should have two slots.", () => {
+		expect(Object.keys(docGrid["slots"]).length).to.equal(2);
+	});
+
+	it("should have a slot named header.", () => {
+		expect(typeof docGrid["slots"]["header"] !== "undefined").to.be.true;
+	});
+
+	it('the header slot should have "Use this slot header" as description', () => {
+		expect(docGrid["slots"]["header"]["description"]).to.equal(
+			"Use this slot header"
+		);
+	});
+
+	it("should have a slot named footer.", () => {
+		expect(typeof docGrid["slots"]["footer"] !== "undefined").to.be.true;
+	});
+
+	it('the footer slot should have "Use this slot footer" as description', () => {
+		expect(docGrid["slots"]["footer"]["description"]).to.equal(
+			"Use this slot footer"
+		);
 	});
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1929,6 +1929,10 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
+typescript@^2.5.0:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
+
 typical@^2.6.0, typical@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/typical/-/typical-2.6.1.tgz#5c080e5d661cbbe38259d2e70a3c7253e873881d"


### PR DESCRIPTION
This abstracts away the parsing logic into a function that takes a
`lang` argument, which comes is extracted by the vue-component-compiler
library. When the language is typescript, it is passed through the
typescript compiler before being passed onto the same babel compiler as
before.

Fixes #9 