### PR TITLE
Add support for index js import & add missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "license": "MIT",
   "homepage": "https://github.com/vue-styleguidist/vue-docgen-api#readme",
   "dependencies": {
+    "babel-cli": "^6.26.0",
     "babel-core": "^6.25.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-runtime": "^6.23.0",

--- a/src/utils/getMixin.js
+++ b/src/utils/getMixin.js
@@ -1,4 +1,5 @@
 import fs from 'fs'
+import path from 'path'
 import stateDoc from './stateDoc'
 import parseModule from './parseModule'
 import evalComponentCode from './evalComponentCode'
@@ -6,7 +7,15 @@ import evalComponentCode from './evalComponentCode'
 module.exports = function getMixin(listRequire) {
   const output = []
   listRequire.forEach(filePath => {
-    const pathRequire = filePath + '.js'
+    let pathRequire;
+    try {
+      fs.lstatSync(filePath).isDirectory();
+      // Path is a folder, add 'index.js' filename
+      pathRequire = path.join(filePath, 'index.js');
+    }catch(e) {
+      // Path is a file, add '.js' extension
+      pathRequire = filePath + '.js'
+    }
     if (fs.existsSync(pathRequire)) {
       const source = fs.readFileSync(pathRequire, {
         encoding: 'utf-8',


### PR DESCRIPTION
Add missing 'babel-cli' dependency (required at npm install step).
When code uses 'import' with a directory path (to import contained 'index.js'), vue-styleguidist fails. This merge request fixes that issue.
