### PR TITLE
Fix for .babelrc handling

### DIFF
--- a/src/utils/getDocFile.js
+++ b/src/utils/getDocFile.js
@@ -4,7 +4,7 @@ const parseModule = require('./parseModule')
 
 export default function getDocFile(source, file, lang) {
   try {
-    const parsedSource = parseModule(source, lang, '2017')
+    const parsedSource = parseModule(source, file, lang, '2017')
     let docReturn = jsdoc
       .explainSync({
         source: parsedSource,

--- a/src/utils/getExtends.js
+++ b/src/utils/getExtends.js
@@ -20,7 +20,7 @@ module.exports = function getExtends(listRequire) {
       const doc = stateDoc.getDocFile(jscode, filePath, jscodeLang)
       stateDoc.saveMixin(doc, filePath)
       if (stateDoc.isMixin()) {
-        const parsedSource = parseModule(jscode, stateDoc.jscodeLang)
+        const parsedSource = parseModule(jscode, filePath, stateDoc.jscodeLang)
         const mixin = evalComponentCode(parsedSource)
         if (Object.keys(mixin.exports).length === 0) {
           mixin.exports.default = mixin.module.exports

--- a/src/utils/getMixin.js
+++ b/src/utils/getMixin.js
@@ -24,7 +24,7 @@ module.exports = function getMixin(listRequire) {
       const doc = stateDoc.getDocFile(source, pathRequire)
       stateDoc.saveMixin(doc, pathRequire)
       if (stateDoc.isMixin()) {
-        const parsedSource = parseModule(source, stateDoc.jscodeLang)
+        const parsedSource = parseModule(source, filePath, stateDoc.jscodeLang)
         const mixin = evalComponentCode(parsedSource)
         if (Object.keys(mixin.exports).length === 0) {
           mixin.exports.default = mixin.module.exports

--- a/src/utils/getParseBabel.js
+++ b/src/utils/getParseBabel.js
@@ -1,12 +1,23 @@
 const babel = require('babel-core')
+const path = require('path')
+const process = require('process')
 
 module.exports = function getParseBabel(
 	code,
+	filename,
 	comments = false
 ) {
+	// Provide filename and cwd to babel for:
+	//  a) Proper loading of .babelrc
+	//  b) Error messages saying where any SyntaxErrors are
+	const cwd = process.cwd()
+	const filenameRelative = path.relative(cwd, filename)
+
 	const options = {
 		ast: false,
 		comments,
+		filename,
+		filenameRelative,
 		presets: [
 			["env", {
 				"targets": {
@@ -14,7 +25,9 @@ module.exports = function getParseBabel(
 				}
 			}]
 		],
-		plugins: ["transform-object-rest-spread"]
+		plugins: ["transform-object-rest-spread"],
+		sourceRoot: cwd
 	}
+
 	return babel.transform(code, options)
 }

--- a/src/utils/getSandbox.js
+++ b/src/utils/getSandbox.js
@@ -5,7 +5,7 @@ import getExtends from './getExtends'
 import parseModule from './parseModule'
 
 module.exports = function getSandbox(stateDoc, file) {
-  const parsedSource = parseModule(stateDoc.jscodeReqest, stateDoc.jscodeLang)
+  const parsedSource = parseModule(stateDoc.jscodeReqest, file, stateDoc.jscodeLang)
   const sandbox = evalComponentCode(parsedSource).exports
   const component = sandbox.default
   const listRequire = getSourceInRequire(parsedSource, file)

--- a/src/utils/parseModule.js
+++ b/src/utils/parseModule.js
@@ -1,14 +1,14 @@
 import getParseTypescript from './getParseTypescript'
 import getParseBabel from './getParseBabel'
 
-module.exports = function parseModule(source, type, preset) {
+module.exports = function parseModule(source, filename, type, preset) {
   const comment = !!preset
   switch (type) {
     case 'ts':
       const tsOutput = getParseTypescript(source)
-      return getParseBabel(tsOutput.outputText, comment).code
+      return getParseBabel(tsOutput.outputText, filename, comment).code
       break
     default:
-      return getParseBabel(source, comment).code
+      return getParseBabel(source, filename, comment).code
   }
 }


### PR DESCRIPTION
I believe I've found a fix for .babelrc loading. We need to pass the filename and sourceRoot options to `babel.transform`. I had to modify a couple of function signatures and their uses to do this.

Solves #40 

Hope you like it!