### PR TITLE
[feat] name components that don't have one

### DIFF
--- a/src/utils/getVueDoc.js
+++ b/src/utils/getVueDoc.js
@@ -1,3 +1,4 @@
+import path from 'path'
 import { IGNORE_DEFAULT, getDescription, getComment, EMPTY } from './variables'
 import processTags from './processTags'
 import processProps from './processProps'
@@ -6,12 +7,14 @@ import processEvents from './processEvents'
 
 export default function getVueDoc(stateDoc, component) {
   let docJsFile = stateDoc.getDocJs()
-  let displayName
   let docComponent
-  if (!component.name || component.name === '') {
-    throw new Error("The component has no name, add 'name' property on the Vue component")
-  }
-  displayName = component.name
+
+  const displayName =
+    !component.name || component.name === ''
+      ? // if component does not have a name, use the name of the file containing it
+        path.basename(stateDoc.file, path.extname(stateDoc.file))
+      : (displayName = component.name)
+
   if (docJsFile) {
     docJsFile = docJsFile.filter(comment => {
       return comment.kind !== 'package'

--- a/src/utils/getVueDoc.js
+++ b/src/utils/getVueDoc.js
@@ -13,7 +13,7 @@ export default function getVueDoc(stateDoc, component) {
     !component.name || component.name === ''
       ? // if component does not have a name, use the name of the file containing it
         path.basename(stateDoc.file, path.extname(stateDoc.file))
-      : (displayName = component.name)
+      : component.name
 
   if (docJsFile) {
     docJsFile = docJsFile.filter(comment => {


### PR DESCRIPTION
I would wish to create more unit tests as a safety net.
Will do that soon this afternoon.

In the meantime this gives the name _button_ to a file in the path  _src/components/tests.vue_

fixing #42 