### PR TITLE
Fix: windows babel issue with require...

### DIFF
--- a/src/utils/evalComponentCode.js
+++ b/src/utils/evalComponentCode.js
@@ -21,7 +21,7 @@ module.exports = function evalComponentCode(code) {
       // depending on the preset that one is running,
       // babel will not always use the root interopRequireDefault
       // for babel es6, it uses .../builtin/es6/interop...
-      if (/@babel\/runtime\/helpers\/.*interopRequireDefault$/.test(element)) {
+      if (/@babel[\\,\/]runtime\/helpers\/.*interopRequireDefault$/.test(element)) {
         return function(value) {
           return value
         }


### PR DESCRIPTION
For some reason, on windows, the @babel thing seems broken again.
It calls "@babel\\runtime/helpers/..." with a backslash to start with.