### PR TITLE
fix: support comment having a longname like _default2

### DIFF
--- a/src/utils/__tests__/getVueDoc.js
+++ b/src/utils/__tests__/getVueDoc.js
@@ -1,0 +1,72 @@
+var getVueDoc = require('../../../dist/utils/getVueDoc').default
+const expect = require('chai').expect
+
+describe('getVueDoc', () => {
+  it('should return right comment for longname default', () => {
+    const result = getVueDoc({
+      file: '',
+      getDocJs: () => [
+        {
+          description: 'Component description',
+          longname: 'default'
+        },
+        {
+          description: 'Prop description',
+          longname: 'default.props.prop'
+        }
+      ]
+    }, {})
+    expect(result.description).to.equal('Component description')
+  })
+
+  it('should return right comment for longname _default', () => {
+    const result = getVueDoc({
+      file: '',
+      getDocJs: () => [
+        {
+          description: 'Component description',
+          longname: '_default'
+        },
+        {
+          description: 'Prop description',
+          longname: '_default.props.prop'
+        }
+      ]
+    }, {})
+    expect(result.description).to.equal('Component description')
+  })
+
+  it('should return right comment for longname default2', () => {
+    const result = getVueDoc({
+      file: '',
+      getDocJs: () => [
+        {
+          description: 'Component description',
+          longname: 'default2'
+        },
+        {
+          description: 'Prop description',
+          longname: 'default2.props.prop'
+        }
+      ]
+    }, {})
+    expect(result.description).to.equal('Component description')
+  })
+
+  it('should return right comment for longname _default2', () => {
+    const result = getVueDoc({
+      file: '',
+      getDocJs: () => [
+        {
+          description: 'Component description',
+          longname: '_default2'
+        },
+        {
+          description: 'Prop description',
+          longname: '_default2.props.prop'
+        }
+      ]
+    }, {})
+    expect(result.description).to.equal('Component description')
+  })
+})

--- a/src/utils/getVueDoc.js
+++ b/src/utils/getVueDoc.js
@@ -23,7 +23,7 @@ export default function getVueDoc(stateDoc, component) {
       return comment.kind !== 'package'
     })
     docComponent = docJsFile.filter(comment => {
-      return comment.longname === 'module.exports' || comment.longname === 'default' || comment.longname === '_default'
+      return comment.longname === 'module.exports' || comment.longname.match(/(_)?default(\d+)?$/g)
     })[0]
   } else {
     docJsFile = []

--- a/tests/components/button-noscript/button-noscript.test.js
+++ b/tests/components/button-noscript/button-noscript.test.js
@@ -5,7 +5,7 @@ const api = require('../../../dist/main')
 const button = path.join(__dirname, './MyButton.vue')
 let docButton
 
-describe.only('tests button', () => {
+describe('tests button', () => {
   before(function(done) {
     this.timeout(10000)
     docButton = api.parse(button)


### PR DESCRIPTION
fix: support comment having a longname like _default2

Closes #59