### PR TITLE
require babel plugins to get default module resolution

### DIFF
--- a/src/utils/getParseBabel.js
+++ b/src/utils/getParseBabel.js
@@ -1,4 +1,7 @@
 const babel = require('@babel/core')
+const presetEnv = require('@babel/preset-env');
+const pluginObjectRestSpread = require('@babel/plugin-proposal-object-rest-spread');
+const pluginTransformVueJsx = require('babel-plugin-transform-vue-jsx');
 const path = require('path')
 const process = require('process')
 
@@ -16,7 +19,7 @@ module.exports = function getJsxBabel(code, filename, comments = false) {
     filenameRelative,
     presets: [
       [
-        '@babel/preset-env',
+        presetEnv,
         {
           targets: {
             chrome: 52,
@@ -24,7 +27,7 @@ module.exports = function getJsxBabel(code, filename, comments = false) {
         },
       ],
     ],
-    plugins: ['@babel/plugin-proposal-object-rest-spread', 'babel-plugin-transform-vue-jsx'],
+    plugins: [pluginObjectRestSpread, pluginTransformVueJsx],
     sourceRoot: cwd,
   }
 


### PR DESCRIPTION
When using [bazel](https://bazel.build/) the `node_modules` are not at the default so I am getting the following error when using vue styleguidist:

```
Error: Cannot find module '@babel/plugin-proposal-object-rest-spread' from '/path/to/styleguide.runfiles/__main__'

Warning: Cannot parse vue/components/icons/icon-base.vue: Error: Error: Cannot find module '@babel/plugin-proposal-object-rest-spread' from '/path/to/styleguide.runfiles/__main__'

It usually means that vue-docgen-api does not understand your source code or when using third-party libraries, try to file an issue here:
https://github.com/vue-styleguidist/vue-docgen-api/issues
```

It seems to me that is due to babel doing its own module/plugin resolution and not using the default require under the hood. Some issues on that topic: https://github.com/babel/babel/issues/7952, https://github.com/babel/babel/issues/6664 & https://github.com/babel/babel/issues/5618

Just requiring the plugins and presets at the top of the file fixes the issue.