### PR TITLE
 feat: resolve body of default function arrow functions 

### DIFF
--- a/src/script-handlers/__tests__/propHandler.ts
+++ b/src/script-handlers/__tests__/propHandler.ts
@@ -198,6 +198,53 @@ describe('propHandler', () => {
         defaultValue: { value: `"normal"` },
       })
     })
+
+    it('should return the body of the function as default value', () => {
+      const src = `
+        export default {
+          props: {
+            test: {
+              default: () => {}
+            }
+          }
+        }
+        `
+      tester(src, {
+        defaultValue: { value: `{}` },
+      })
+    })
+
+    it('should return the body of the function as default value without parenthesis', () => {
+      const src = `
+        export default {
+          props: {
+            test: {
+              default: () => ({})
+            }
+          }
+        }
+        `
+      tester(src, {
+        defaultValue: { value: `{}` },
+      })
+    })
+
+    it('should return the body of the function as default value without parenthesis', () => {
+      const src = `
+        export default {
+          props: {
+            test: {
+              default() {
+                return {}
+              }
+            }
+          }
+        }
+        `
+      tester(src, {
+        defaultValue: { value: `{}` },
+      })
+    })
   })
 
   describe('description', () => {

--- a/src/script-handlers/propHandler.ts
+++ b/src/script-handlers/propHandler.ts
@@ -139,7 +139,10 @@ export function describeDefault(
     let defaultPath = defaultArray[0].get('value')
 
     let parenthesized = false
-    if (bt.isArrowFunctionExpression(defaultPath.node)) {
+    if (
+      bt.isArrowFunctionExpression(defaultPath.node) &&
+      bt.isObjectExpression(defaultPath.node.body)
+    ) {
       defaultPath = defaultPath.get('body')
       const extra = (defaultPath.node as any).extra
       if (extra && extra.parenthesized) {

--- a/src/script-handlers/propHandler.ts
+++ b/src/script-handlers/propHandler.ts
@@ -136,13 +136,21 @@ export function describeDefault(
 ) {
   const defaultArray = propPropertiesPath.filter(p => p.node.key.name === 'default')
   if (defaultArray.length) {
-    const defaultPath = defaultArray[0].get('value')
+    let defaultPath = defaultArray[0].get('value')
 
-    const func =
-      bt.isArrowFunctionExpression(defaultPath.node) || bt.isFunctionExpression(defaultPath.node)
+    let parenthesized = false
+    if (bt.isArrowFunctionExpression(defaultPath.node)) {
+      defaultPath = defaultPath.get('body')
+      const extra = (defaultPath.node as any).extra
+      if (extra && extra.parenthesized) {
+        parenthesized = true
+      }
+    }
+
+    const rawValue = recast.print(defaultPath).code
     propDescriptor.defaultValue = {
-      func,
-      value: recast.print(defaultPath).code,
+      func: bt.isFunction(defaultPath.node),
+      value: parenthesized ? rawValue.slice(1, rawValue.length - 1) : rawValue,
     }
   }
 }


### PR DESCRIPTION
When we have 
```js
props:{
  myProp:{
    default: () => ({
        data: 2
      })
  }
}
```
the output now is
```js
{
  defaultValue: {
    value: ()=> ({data:2})
  }
}
```
and should be 
```js
{
  defaultValue: {
    value: {data:2}
  }
}
```
      