### PR TITLE
fix: event anonymous properties

### DIFF
--- a/src/script-handlers/__tests__/eventHandler.ts
+++ b/src/script-handlers/__tests__/eventHandler.ts
@@ -76,13 +76,13 @@ describe('eventHandler', () => {
       description: '',
       properties: [
         {
-          name: '<anonymous>',
+          name: '<anonymous1>',
           type: {
             names: ['undefined'],
           },
         },
         {
-          name: '<anonymous>',
+          name: '<anonymous2>',
           type: {
             names: ['undefined'],
           },

--- a/src/script-handlers/eventHandler.ts
+++ b/src/script-handlers/eventHandler.ts
@@ -53,7 +53,7 @@ export default function eventHandler(documentation: Documentation, path: NodePat
           while (i--) {
             evtDescriptor.properties.push({
               type: { names: ['undefined'] },
-              name: `<anonymous${args.length - i}>`,
+              name: `<anonymous${args.length - i - 1}>`,
             })
           }
         }

--- a/src/script-handlers/eventHandler.ts
+++ b/src/script-handlers/eventHandler.ts
@@ -53,7 +53,7 @@ export default function eventHandler(documentation: Documentation, path: NodePat
           while (i--) {
             evtDescriptor.properties.push({
               type: { names: ['undefined'] },
-              name: '<anonymous>',
+              name: `<anonymous${args.length - i}>`,
             })
           }
         }

--- a/tests/components/button-typescript/__snapshots__/button-ts.test.ts.snap
+++ b/tests/components/button-typescript/__snapshots__/button-ts.test.ts.snap
@@ -9,7 +9,7 @@ Object {
       "description": "Success event when we click",
       "properties": Array [
         Object {
-          "name": "<anonymous2>",
+          "name": "<anonymous1>",
           "type": Object {
             "names": Array [
               "undefined",

--- a/tests/components/button-typescript/__snapshots__/button-ts.test.ts.snap
+++ b/tests/components/button-typescript/__snapshots__/button-ts.test.ts.snap
@@ -9,7 +9,7 @@ Object {
       "description": "Success event when we click",
       "properties": Array [
         Object {
-          "name": "<anonymous>",
+          "name": "<anonymous2>",
           "type": Object {
             "names": Array [
               "undefined",

--- a/tests/components/grid-jsx/__snapshots__/grid-jsx.test.ts.snap
+++ b/tests/components/grid-jsx/__snapshots__/grid-jsx.test.ts.snap
@@ -9,7 +9,7 @@ Object {
       "description": "Error event.",
       "properties": Array [
         Object {
-          "name": "<anonymous>",
+          "name": "<anonymous2>",
           "type": Object {
             "names": Array [
               "undefined",
@@ -27,7 +27,7 @@ Object {
       "description": "Success event.",
       "properties": Array [
         Object {
-          "name": "<anonymous>",
+          "name": "<anonymous2>",
           "type": Object {
             "names": Array [
               "undefined",

--- a/tests/components/grid-jsx/__snapshots__/grid-jsx.test.ts.snap
+++ b/tests/components/grid-jsx/__snapshots__/grid-jsx.test.ts.snap
@@ -9,7 +9,7 @@ Object {
       "description": "Error event.",
       "properties": Array [
         Object {
-          "name": "<anonymous2>",
+          "name": "<anonymous1>",
           "type": Object {
             "names": Array [
               "undefined",
@@ -27,7 +27,7 @@ Object {
       "description": "Success event.",
       "properties": Array [
         Object {
-          "name": "<anonymous2>",
+          "name": "<anonymous1>",
           "type": Object {
             "names": Array [
               "undefined",

--- a/tests/components/grid-typescript/__snapshots__/grid-ts.test.ts.snap
+++ b/tests/components/grid-typescript/__snapshots__/grid-ts.test.ts.snap
@@ -9,7 +9,7 @@ Object {
       "description": "Error event.",
       "properties": Array [
         Object {
-          "name": "<anonymous>",
+          "name": "<anonymous2>",
           "type": Object {
             "names": Array [
               "undefined",
@@ -27,7 +27,7 @@ Object {
       "description": "Success event.",
       "properties": Array [
         Object {
-          "name": "<anonymous>",
+          "name": "<anonymous2>",
           "type": Object {
             "names": Array [
               "undefined",

--- a/tests/components/grid-typescript/__snapshots__/grid-ts.test.ts.snap
+++ b/tests/components/grid-typescript/__snapshots__/grid-ts.test.ts.snap
@@ -9,7 +9,7 @@ Object {
       "description": "Error event.",
       "properties": Array [
         Object {
-          "name": "<anonymous2>",
+          "name": "<anonymous1>",
           "type": Object {
             "names": Array [
               "undefined",
@@ -27,7 +27,7 @@ Object {
       "description": "Success event.",
       "properties": Array [
         Object {
-          "name": "<anonymous2>",
+          "name": "<anonymous1>",
           "type": Object {
             "names": Array [
               "undefined",

--- a/tests/components/grid/__snapshots__/grid.test.ts.snap
+++ b/tests/components/grid/__snapshots__/grid.test.ts.snap
@@ -9,7 +9,7 @@ Object {
       "description": "Error event.",
       "properties": Array [
         Object {
-          "name": "<anonymous>",
+          "name": "<anonymous2>",
           "type": Object {
             "names": Array [
               "undefined",
@@ -27,7 +27,7 @@ Object {
       "description": "Success event.",
       "properties": Array [
         Object {
-          "name": "<anonymous>",
+          "name": "<anonymous2>",
           "type": Object {
             "names": Array [
               "undefined",

--- a/tests/components/grid/__snapshots__/grid.test.ts.snap
+++ b/tests/components/grid/__snapshots__/grid.test.ts.snap
@@ -9,7 +9,7 @@ Object {
       "description": "Error event.",
       "properties": Array [
         Object {
-          "name": "<anonymous2>",
+          "name": "<anonymous1>",
           "type": Object {
             "names": Array [
               "undefined",
@@ -27,7 +27,7 @@ Object {
       "description": "Success event.",
       "properties": Array [
         Object {
-          "name": "<anonymous2>",
+          "name": "<anonymous1>",
           "type": Object {
             "names": Array [
               "undefined",


### PR DESCRIPTION
when writing multiple anonymous properties in an event, they allhavethe same name. this fixes the issue. 