### PR TITLE
fix: props definition priority should be script > template

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -48,6 +48,11 @@ export function parseSource(documentation: Documentation, source: string, opt: P
     parts = cacher(() => parseComponent(source), source)
   }
 
+  // get slots and props from template
+  if (parts && parts.template) {
+    parseTemplate(parts.template, documentation, templateHandlers, opt.filePath)
+  }
+
   const scriptSource = parts ? (parts.script ? parts.script.content : undefined) : source
   if (scriptSource) {
     opt.lang =
@@ -57,11 +62,6 @@ export function parseSource(documentation: Documentation, source: string, opt: P
         : 'js'
 
     parseScript(scriptSource, documentation, handlers, opt)
-  }
-
-  // get slots from template
-  if (parts && parts.template) {
-    parseTemplate(parts.template, documentation, templateHandlers, opt.filePath)
   }
 
   if (!documentation.get('displayName')) {

--- a/src/template-handlers/__tests__/propHandler.ts
+++ b/src/template-handlers/__tests__/propHandler.ts
@@ -21,7 +21,7 @@ describe('slotHandler', () => {
     ).ast
     if (ast) {
       traverse(ast, doc, [propHandler], { functional: true })
-      expect(doc.toObject().props).toMatchObject({ size: { type: { name: 'string' } } })
+      expect(doc.toObject().props).toMatchObject({ size: { type: { name: 'undefined' } } })
     } else {
       fail()
     }
@@ -41,18 +41,36 @@ describe('slotHandler', () => {
     ).ast
     if (ast) {
       traverse(ast, doc, [propHandler], { functional: true })
-      expect(doc.toObject().props).toMatchObject({ name: { type: { name: 'string' } } })
+      expect(doc.toObject().props).toMatchObject({ name: { type: { name: 'undefined' } } })
     } else {
       fail()
     }
   })
 
-  it('should not match props if in a litteral', () => {
+  it('should not match props if in a string litteral', () => {
     const ast = compile(
       [
         '<div>',
         '  <h1>titleof the template</h1>',
         '  <button :style="`width:props.size`"></slot>',
+        '</div>',
+      ].join('\n'),
+      { comments: true },
+    ).ast
+    if (ast) {
+      traverse(ast, doc, [propHandler], { functional: true })
+      expect(doc.toObject().props).toBeUndefined()
+    } else {
+      fail()
+    }
+  })
+
+  it('should not match props if in a non evaluated attribute', () => {
+    const ast = compile(
+      [
+        '<div>',
+        '  <h1>titleof the template</h1>',
+        '  <button style="width:props.size"></slot>',
         '</div>',
       ].join('\n'),
       { comments: true },

--- a/src/template-handlers/propHandler.ts
+++ b/src/template-handlers/propHandler.ts
@@ -57,7 +57,7 @@ function getPropsFromExpression(expression: string, documentation: Documentation
       ) {
         const pName = propName.name
         const p = documentation.getPropDescriptor(pName)
-        p.type = { name: 'string' }
+        p.type = { name: 'undefined' }
       }
       return false
     },

--- a/tests/components/button-functinoal/MyButton.vue
+++ b/tests/components/button-functinoal/MyButton.vue
@@ -7,3 +7,12 @@
     {{props.text}}
   </div>
 </template>
+
+<script>
+export default {
+  props: {
+    size: Number,
+    default: 200,
+  },
+}
+</script>

--- a/tests/components/button-functinoal/__snapshots__/button-functional.test.ts.snap
+++ b/tests/components/button-functinoal/__snapshots__/button-functional.test.ts.snap
@@ -7,18 +7,26 @@ Object {
   "events": Object {},
   "methods": Array [],
   "props": Object {
+    "default": Object {
+      "description": "",
+      "tags": Object {},
+      "type": Object {
+        "func": true,
+        "name": "200",
+      },
+    },
     "size": Object {
       "description": "",
       "tags": Object {},
       "type": Object {
-        "name": "string",
+        "name": "number",
       },
     },
     "text": Object {
       "description": "",
       "tags": Object {},
       "type": Object {
-        "name": "string",
+        "name": "undefined",
       },
     },
   },

--- a/tests/components/button-functinoal/button-functional.test.ts
+++ b/tests/components/button-functinoal/button-functional.test.ts
@@ -21,8 +21,8 @@ describe('tests button functional', () => {
 
   it('should extract props from template if functional', () => {
     expect(docButton.props).toMatchObject({
-      size: { type: { name: 'string' } },
-      text: { type: { name: 'string' } },
+      size: { type: { name: 'number' } },
+      text: { type: { name: 'undefined' } },
     })
   })
 


### PR DESCRIPTION
A component like this:

```vue
<template functional>
  <img :src="props.source" :width="props.width"/>
</template>
<script>
export default {
  props:{
    width: Number
  }
}
</script>
```

returns `width` as a string prop...